### PR TITLE
Fix two issues with cogserver I/O.

### DIFF
--- a/vis-word-pairs/fract.html
+++ b/vis-word-pairs/fract.html
@@ -573,7 +573,7 @@
                             query += ")";
                         query += ")";
                         
-                        sendcmd (query + "\n").then (
+                        sendcmd (query + "(newline)\n").then (
                             (response) => {
                                 // stats
                                 try {
@@ -607,12 +607,18 @@
             function setChildren (data, rel) {
                 var ret = [];
                 while (Array.isArray(rel[2])) {
-                    var txt = rel[0][1][1][2];
+                    var txta = rel[0][1][1][2];
+                    var txt = txta;
+                    if (typeof txt != 'string')
+                        txt = txta[0];
                     ret.push (txt.substr (1, txt.length - 2));
                     rel = rel[2];
                 }
                 
-                var txt = rel[1][1][2];
+                var txta = rel[1][1][2];
+                var txt = txta;
+                if (typeof txt != 'string')
+                    txt = txta[0];
                 ret.push (txt.substr (1, txt.length - 2));
 
                 data.children = [];


### PR DESCRIPTION
Issue 1: work around a missing newline in the reply; without this, the `telnet.php` hangs waiting for a response.

Issue 2: Work around the case where the cogserver might return either `(WordNode "foo")` or might return `(WordNode "foo" (ctv 1 0 54))`. In the second case, `setChildren` gets an array instead of a string.

See issue #5 for details